### PR TITLE
Compatibility/vs code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ bin/*.dat
 bin/*.bin
 bin/servers/default/logs/serverlog.txt
 bin/servers/default/logs/npclog.txt
+bin/servers/default/npcs/npcControl-NPC.txt
 bin/startuplog.txt
 mybin/*
 build*/*

--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,5 @@ dependencies/.cipd/
 bin/servers/*
 *.swp
 .svn/
+packages/*
+*.bat

--- a/.gitignore
+++ b/.gitignore
@@ -21,5 +21,5 @@ dependencies/.cipd/
 bin/servers/*
 *.swp
 .svn/
-packages/*
+packages/
 *.bat

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -217,13 +217,17 @@ if(NOT NOSTATIC)
 endif()
 
 if(V8NPCSERVER)
-	if(NOT MSVC)
-		find_package(V8)
+	# Removing MSVC check because using VSCode with MSVC sets both MSVC and MSVC_IDE as true
+	# Hopefully we will find another way to diffenrentiate between using VSCode and Visual Studio Community
+	# if(NOT MSVC)
 		if(NOT V8_FOUND)
-			message("v8 not found in system")
-			#add_subdirectory(${PROJECT_SOURCE_DIR}/cmake/v8)
+			find_package(V8)
+			if(NOT V8_FOUND)
+				message("v8 not found in system")
+				#add_subdirectory(${PROJECT_SOURCE_DIR}/cmake/v8)
+			endif()
 		endif()
-	endif()
+	#endif()
 endif()
 
 if(NOT NOUPNP)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,8 +22,6 @@
 cmake_minimum_required(VERSION 2.8.5)
 project(GS2Emu C CXX)
 
-message("Expanding ${PROJECT_NAME} cmake")
-
 set(CMAKE_DEBUG_POSTFIX _d)
 
 set(BIN_DIR "bin" CACHE STRING "Binary output directory")
@@ -250,7 +248,7 @@ if(NOT NOUPNP)
 	endif()
 endif()
 
-if(NOT MSVC)
+if(NOT WIN32)
 	find_package(Threads REQUIRED)
 endif()
 
@@ -264,4 +262,3 @@ add_subdirectory(${PROJECT_SOURCE_DIR}/bin)
 add_subdirectory(${PROJECT_SOURCE_DIR}/server)
 set_property(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR} PROPERTY VS_STARTUP_PROJECT ${PROJECT_NAME})
 
-message("${PROJECT_NAME} cmake done expanding")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,6 +22,8 @@
 cmake_minimum_required(VERSION 2.8.5)
 project(GS2Emu C CXX)
 
+message("Expanding ${PROJECT_NAME} cmake")
+
 set(CMAKE_DEBUG_POSTFIX _d)
 
 set(BIN_DIR "bin" CACHE STRING "Binary output directory")
@@ -217,17 +219,11 @@ if(NOT NOSTATIC)
 endif()
 
 if(V8NPCSERVER)
-	# Removing MSVC check because using VSCode with MSVC sets both MSVC and MSVC_IDE as true
-	# Hopefully we will find another way to diffenrentiate between using VSCode and Visual Studio Community
-	# if(NOT MSVC)
-		if(NOT V8_FOUND)
-			find_package(V8)
-			if(NOT V8_FOUND)
-				message("v8 not found in system")
-				#add_subdirectory(${PROJECT_SOURCE_DIR}/cmake/v8)
-			endif()
-		endif()
-	#endif()
+	find_package(V8)
+	if(NOT V8_FOUND)
+		message("v8 not found in system")
+		#add_subdirectory(${PROJECT_SOURCE_DIR}/cmake/v8)
+	endif()
 endif()
 
 if(NOT NOUPNP)
@@ -254,7 +250,9 @@ if(NOT NOUPNP)
 	endif()
 endif()
 
-find_package(Threads REQUIRED)
+if(NOT MSVC)
+	find_package(Threads REQUIRED)
+endif()
 
 # Restore library suffixes
 if(NOT NOSTATIC)
@@ -265,3 +263,5 @@ add_subdirectory(${PROJECT_SOURCE_DIR}/dependencies/gs2lib)
 add_subdirectory(${PROJECT_SOURCE_DIR}/bin)
 add_subdirectory(${PROJECT_SOURCE_DIR}/server)
 set_property(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR} PROPERTY VS_STARTUP_PROJECT ${PROJECT_NAME})
+
+message("${PROJECT_NAME} cmake done expanding")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -220,7 +220,6 @@ if(V8NPCSERVER)
 	find_package(V8)
 	if(NOT V8_FOUND)
 		message("v8 not found in system")
-		#add_subdirectory(${PROJECT_SOURCE_DIR}/cmake/v8)
 	endif()
 endif()
 
@@ -261,4 +260,3 @@ add_subdirectory(${PROJECT_SOURCE_DIR}/dependencies/gs2lib)
 add_subdirectory(${PROJECT_SOURCE_DIR}/bin)
 add_subdirectory(${PROJECT_SOURCE_DIR}/server)
 set_property(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR} PROPERTY VS_STARTUP_PROJECT ${PROJECT_NAME})
-

--- a/README.md
+++ b/README.md
@@ -55,6 +55,10 @@ cd build
 cmake .. -G "Visual Studio 16 2019" -A x64 -DV8NPCSERVER=TRUE
 
 cmake --build .
+
+//The next lines copy the required v8 files to the build path.
+robocopy ..\packages\v8.redist-v142-x64.7.4.288.26\lib\Debug ..\bin\ *.dll
+robocopy ..\packages\v8.redist-v142-x64.7.4.288.26\lib\Debug ..\bin\ *.bin
 ```
 
 ## Quick Start Instructions

--- a/README.md
+++ b/README.md
@@ -37,7 +37,6 @@ A folder called GServer-v2 will be created. Remember to update the Visual Studio
 ```
 git clone https://github.com/xtjoeytx/GServer-v2
 cd GServer-v2
-git checkout feature/npc-server
 git submodule update --init --recursive
 
 mkdir packages

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ For their additional work on the old gserver, special thanks go to:
 	
 ## Building
 
+### On *nix machines
 ```
 fetch v8
 cd v8
@@ -18,6 +19,40 @@ tools/dev/v8gen.py x64.release.sample
 ninja -j 8 -C out.gn/x64.release.sample v8_monolith
 ```
 
+### On Windows, using GCC
+Currently, v8 is too much of a pain to build for this method to be viable. We suggest you use MSVC/MSBuild and nuget instead.
+
+### On Windows, using MSVC/MSBuild
+#### First, setup the environment:
+Install Microsoft C++ compiler and latest Windows SDK through the [VS installer](https://docs.microsoft.com/en-us/visualstudio/install/install-visual-studio?view=vs-2019)
+Install and add [CMake](https://cmake.org/download/) to path
+Download and add [nuget](https://www.nuget.org/downloads) to path
+Add `D:\Program Files (x86)\Microsoft Visual Studio\2019\Community\MSBuild\Microsoft\VC\v160\` to `VCTargetsPath` in your paths. Note that your actual installation path (folder in which `Microsoft Visual Studio` is) may be different in your environment. The trailing \ can be required.
+
+#### Then, running these commands should work.
+A folder called GServer-v2 will be created. Remember to update the Visual Studio installation path to your Visual Studio installation path.
+```
+git clone https://github.com/xtjoeytx/GServer-v2
+cd GServer-v2
+git checkout feature/npc-server
+git submodule update --init --recursive
+
+mkdir packages
+cd packages
+
+nuget install v8-v142-x64 -version 7.4.288.26
+
+cd..
+
+mkdir build
+cd build
+
+"D:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Auxiliary\Build\vcvarsall.bat" x64
+
+cmake .. -G "Visual Studio 16 2019" -A x64 -DV8NPCSERVER=TRUE
+
+cmake --build .
+```
 
 ## Quick Start Instructions
 

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ cd ..
 mkdir build
 cd build
 
-"D:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Auxiliary\Build\vcvarsall.bat" x64
+"%programfiles(x86)%\Microsoft Visual Studio\2019\Community\VC\Auxiliary\Build\vcvarsall.bat" x64
 
 cmake .. -G "Visual Studio 16 2019" -A x64 -DV8NPCSERVER=TRUE
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ ninja -j 8 -C out.gn/x64.release.sample v8_monolith
 Currently, v8 is too much of a pain to build for this method to be viable. We suggest you use MSVC/MSBuild and nuget instead.
 
 ### On Windows, using MSVC/MSBuild
-#### First, setup the environment:
+#### Setup the environment:
 Install Microsoft C++ compiler and latest Windows SDK through the [VS installer](https://docs.microsoft.com/en-us/visualstudio/install/install-visual-studio?view=vs-2019)
 
 Install and add [CMake](https://cmake.org/download/) to path

--- a/README.md
+++ b/README.md
@@ -25,8 +25,11 @@ Currently, v8 is too much of a pain to build for this method to be viable. We su
 ### On Windows, using MSVC/MSBuild
 #### First, setup the environment:
 Install Microsoft C++ compiler and latest Windows SDK through the [VS installer](https://docs.microsoft.com/en-us/visualstudio/install/install-visual-studio?view=vs-2019)
+
 Install and add [CMake](https://cmake.org/download/) to path
+
 Download and add [nuget](https://www.nuget.org/downloads) to path
+
 Add `D:\Program Files (x86)\Microsoft Visual Studio\2019\Community\MSBuild\Microsoft\VC\v160\` to `VCTargetsPath` in your paths. Note that your actual installation path (folder in which `Microsoft Visual Studio` is) may be different in your environment. The trailing \ can be required.
 
 #### Then, running these commands should work.

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Download and add [nuget](https://www.nuget.org/downloads) to path
 
 Add `D:\Program Files (x86)\Microsoft Visual Studio\2019\Community\MSBuild\Microsoft\VC\v160\` to `VCTargetsPath` in your paths. Note that your actual installation path (folder in which `Microsoft Visual Studio` is) may be different in your environment. The trailing \ can be required.
 
-#### Then, running these commands should work.
+#### Building the server with NPC-server support enabled
 A folder called GServer-v2 will be created. Remember to update the Visual Studio installation path to your Visual Studio installation path.
 ```
 git clone https://github.com/xtjoeytx/GServer-v2

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ cd packages
 
 nuget install v8-v142-x64 -version 7.4.288.26
 
-cd..
+cd ..
 
 mkdir build
 cd build

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Install and add [CMake](https://cmake.org/download/) to path
 
 Download and add [nuget](https://www.nuget.org/downloads) to path
 
-Add `D:\Program Files (x86)\Microsoft Visual Studio\2019\Community\MSBuild\Microsoft\VC\v160\` to `VCTargetsPath` in your paths. Note that your actual installation path (folder in which `Microsoft Visual Studio` is) may be different in your environment. The trailing \ can be required.
+Add `%programfiles(x86)%\Microsoft Visual Studio\2019\Community\MSBuild\Microsoft\VC\v160\` to `VCTargetsPath` in your system paths. The trailing \ may be required.
 
 #### Building the server with NPC-server support enabled
 A folder called GServer-v2 will be created. Remember to update the Visual Studio installation path to your Visual Studio installation path.

--- a/cmake/FindV8.cmake
+++ b/cmake/FindV8.cmake
@@ -8,10 +8,6 @@
 
 message("Looking for monolithic v8...")
 
-if(NOSTATIC)
-	message("Ignoring NOSTATIC for v8 lookup")
-endif()
-
 IF (NOT $ENV{V8_DIR} STREQUAL "")
 	SET(V8_DIR $ENV{V8_DIR})
 ENDIF()

--- a/cmake/FindV8.cmake
+++ b/cmake/FindV8.cmake
@@ -6,6 +6,12 @@
 # V8_FOUND, if false, do not try to link to V8
 # V8_INCLUDE_DIR, where to find the headers
 
+message("Looking for monolithic v8...")
+
+if(NOSTATIC)
+	message("Ignoring NOSTATIC for v8 lookup")
+endif()
+
 IF (NOT $ENV{V8_DIR} STREQUAL "")
 	SET(V8_DIR $ENV{V8_DIR})
 ENDIF()
@@ -63,6 +69,7 @@ SET(V8_LIBRARY_SEARCH_PATHS
 	/opt/csw/lib
 	/opt/lib
 	/usr/freeware/lib64
+
 )
 
 FIND_PATH(V8_INCLUDE_DIR v8.h
@@ -87,13 +94,59 @@ FIND_LIBRARY(V8_LIBRARY
 	PATHS ${V8_LIBRARY_SEARCH_PATHS}
 )
 
-SET(V8_FOUND "NO")
+if(NOT V8_LIBRARY OR NOT V8_INCLUDE_DIR)
+	if(NOT V8_LIBRARY)
+		message("Couldn't find v8 library.")
+	endif()
+	if(NOT V8_INCLUDE_DIR)
+		message("Couldn't find v8 include dir.")
+	endif()
+	message("Monolith search failed, looking for nuget package")
 
-IF (NOT UNIX)
-	IF (V8_LIBRARY AND V8_INCLUDE_DIR)
-		SET(V8_FOUND "YES")
-	ENDIF()
-ELSEIF(V8_LIBRARY AND V8_INCLUDE_DIR)
-	SET(V8_FOUND "YES")
-ENDIF(NOT UNIX)
+	find_path(V8_INCLUDE_DIR v8.h
+		PATHS
+		${PROJECT_SOURCE_DIR}/packages/v8-v142-x64.7.4.288.26/include
+		${V8_DIR}/include)
+
+	if(CMAKE_BUILD_TYPE STREQUAL "Release")
+		message("Searching for Release library as chosen")
+		set(V8_LIBRARY_SEARCH_PATHS
+			${PROJECT_SOURCE_DIR}/packages/v8-v142-x64.7.4.288.26/lib/Release
+			${V8_DIR}/Release
+			${V8_DIR}/lib/Release
+		)
+	else()
+		if(NOT CMAKE_BUILD_TYPE)
+			message("Searching for Debug library by default")
+		elseif(CMAKE_BUILD_TYPE STREQUAL "Debug")
+			message("Searching for Debug library as chosen")
+		else()
+			message("Build type not recognized, searching for Debug library")
+		endif()
+		set(V8_LIBRARY_SEARCH_PATHS
+			${PROJECT_SOURCE_DIR}/packages/v8-v142-x64.7.4.288.26/lib/Debug
+			${V8_DIR}/Debug
+			${V8_DIR}/lib/Debug
+		)
+	endif()
+
+	find_library(V8_LIBRARY v8.dll.lib
+		PATHS ${V8_LIBRARY_SEARCH_PATHS}
+	)
+
+	if(NOT V8_LIBRARY)
+		message("Couldn't find v8 library as nuget package")
+	endif()
+	if(NOT V8_INCLUDE_DIR)
+		message("Couldn't find v8 include dir as nuget package")
+	endif()
+
+endif()
+	
+IF (V8_LIBRARY AND V8_INCLUDE_DIR)
+	message("V8 found!")
+	set(V8_FOUND TRUE)
+ELSE()
+	message("V8 lookup failed.")
+ENDIF()
 

--- a/cmake/FindV8.cmake
+++ b/cmake/FindV8.cmake
@@ -109,7 +109,7 @@ if(NOT V8_LIBRARY OR NOT V8_INCLUDE_DIR)
 		${V8_DIR}/include)
 
 	if(CMAKE_BUILD_TYPE STREQUAL "Release")
-		message("Searching for Release library as chosen")
+		message("Searching for Release libraries as chosen")
 		set(V8_LIBRARY_SEARCH_PATHS
 			${PROJECT_SOURCE_DIR}/packages/v8-v142-x64.7.4.288.26/lib/Release
 			${V8_DIR}/Release
@@ -117,11 +117,11 @@ if(NOT V8_LIBRARY OR NOT V8_INCLUDE_DIR)
 		)
 	else()
 		if(NOT CMAKE_BUILD_TYPE)
-			message("Searching for Debug library by default")
+			message("Searching for Debug libraries by default")
 		elseif(CMAKE_BUILD_TYPE STREQUAL "Debug")
 			message("Searching for Debug library as chosen")
 		else()
-			message("Build type not recognized, searching for Debug library")
+			message("Build type not recognized, searching for Debug libraries")
 		endif()
 		set(V8_LIBRARY_SEARCH_PATHS
 			${PROJECT_SOURCE_DIR}/packages/v8-v142-x64.7.4.288.26/lib/Debug
@@ -130,12 +130,18 @@ if(NOT V8_LIBRARY OR NOT V8_INCLUDE_DIR)
 		)
 	endif()
 
-	find_library(V8_LIBRARY v8.dll.lib
+	find_library(V8_MAIN_LIBRARY v8.dll.lib
+		PATHS ${V8_LIBRARY_SEARCH_PATHS}
+	)
+	find_library(V8_BASE_LIBRARY v8_libbase.dll.lib
+		PATHS ${V8_LIBRARY_SEARCH_PATHS}
+	)
+	find_library(V8_PLATFORM_LIBRARY v8_libplatform.dll.lib
 		PATHS ${V8_LIBRARY_SEARCH_PATHS}
 	)
 
-	if(NOT V8_LIBRARY)
-		message("Couldn't find v8 library as nuget package")
+	if(NOT V8_MAIN_LIBRARY OR NOT V8_BASE_LIBRARY OR NOT V8_PLATFORM_LIBRARY)
+		message("Couldn't find v8 libraries as nuget package")
 	endif()
 	if(NOT V8_INCLUDE_DIR)
 		message("Couldn't find v8 include dir as nuget package")
@@ -143,7 +149,9 @@ if(NOT V8_LIBRARY OR NOT V8_INCLUDE_DIR)
 
 endif()
 	
-IF (V8_LIBRARY AND V8_INCLUDE_DIR)
+
+
+IF (V8_INCLUDE_DIR AND ((V8_LIBRARY) OR (V8_MAIN_LIBRARY AND V8_BASE_LIBRARY AND V8_PLATFORM_LIBRARY)))
 	message("V8 found!")
 	set(V8_FOUND TRUE)
 ELSE()

--- a/server/CMakeLists.txt
+++ b/server/CMakeLists.txt
@@ -19,8 +19,6 @@
 #  along with GS2Emu.  If not, see <http://www.gnu.org/licenses/>.
 #
 
-message("Expanding ${PROJECT_NAME} cmake")
-
 include(CheckFunctionExists)
 include(CheckSymbolExists)
 
@@ -252,4 +250,3 @@ set(INSTALL_DEST .)
 
 install(TARGETS ${TARGET_NAME} DESTINATION ${INSTALL_DEST})
 
-message("${PROJECT_NAME} cmake done expanding")

--- a/server/CMakeLists.txt
+++ b/server/CMakeLists.txt
@@ -19,6 +19,8 @@
 #  along with GS2Emu.  If not, see <http://www.gnu.org/licenses/>.
 #
 
+message("Expanding ${PROJECT_NAME} cmake")
+
 include(CheckFunctionExists)
 include(CheckSymbolExists)
 
@@ -188,7 +190,12 @@ elseif(WIN32)
 		set_target_properties(${TARGET_NAME} PROPERTIES VS_DEBUGGER_WORKING_DIRECTORY "${PROJECT_SOURCE_DIR}/bin")
 
 		if(V8NPCSERVER)
-			target_link_libraries(${TARGET_NAME} v8.dll.lib v8_libbase.dll.lib v8_libplatform.dll.lib)
+			# Using MSVC now looks for V8 as a nuget package first
+			# Looking in lib folders if not found
+			if(NOT V8_FOUND)
+				message("Findv8 failed, looking for v8 in supplied folders")
+				target_link_libraries(${TARGET_NAME} v8.dll.lib v8_libbase.dll.lib v8_libplatform.dll.lib)
+			endif()
 		endif()
 	endif()
 elseif(EMSCRIPTEN)
@@ -225,7 +232,11 @@ if(V8NPCSERVER)
 		add_dependencies(${TARGET_NAME} v8)
 		target_link_libraries(${TARGET_NAME} ${V8_LIBRARY})
 	else()
-		target_link_libraries(${TARGET_NAME} ${V8_LIBRARY})
+		if(V8_LIBRARY)
+			target_link_libraries(${TARGET_NAME} ${V8_LIBRARY})
+		else()
+			target_link_libraries(${TARGET_NAME} ${V8_MAIN_LIBRARY} ${V8_BASE_LIBRARY} ${V8_PLATFORM_LIBRARY})
+		endif()
 	endif()
 endif()
 
@@ -240,3 +251,5 @@ install(FILES ${TEXT} DESTINATION ${INSTALL_DEST})
 set(INSTALL_DEST .)
 
 install(TARGETS ${TARGET_NAME} DESTINATION ${INSTALL_DEST})
+
+message("${PROJECT_NAME} cmake done expanding")

--- a/server/src/TPlayer.cpp
+++ b/server/src/TPlayer.cpp
@@ -843,7 +843,7 @@ void TPlayer::testTouch()
 {
 #ifdef V8NPCSERVER
 	// 2, 3
-	static int touchtestd[] = { 24,16, 8,32, 24,48, 40,32 };
+	static int touchtestd[] = { 24,16, 8,32, 24,48, 46,32 };
 	int dir = sprite % 4;
 
 	auto npcList = level->testTouch(x2 + touchtestd[dir * 2], y2 + touchtestd[dir * 2 + 1]);


### PR DESCRIPTION
Added VSCode compatibility through nuget package lookup (Findv8.cmake bigger and _badder_ will now inform of everything that's going on), a couple minor fixes and (hopefully) complete instructions for building on Windows using MSVC/MSBuild.

Tried to make it so it doesn't break on anyone else's toolchain, only adding mine.

Note that this will not work unless GS2lib is updated to add strsep, files were sent to Joey.