### PR TITLE
Remove the ability to launch multiple servers.

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -40,7 +40,6 @@ IndentCaseLabels: true
 IndentPPDirectives: None
 IndentWidth: 4
 KeepEmptyLinesAtTheStartOfBlocks: true
-LineEnding: DeriveLF
 MaxEmptyLinesToKeep: 1
 NamespaceIndentation: All
 ObjCSpaceAfterProperty: false

--- a/bin/servers.txt
+++ b/bin/servers.txt
@@ -1,2 +1,0 @@
-servercount = 1
-server_1 = default

--- a/bin/startupserver.txt
+++ b/bin/startupserver.txt
@@ -1,0 +1,1 @@
+default


### PR DESCRIPTION
Removes the multi-threading on servers.
Removes servers.txt and replaces it with startupserver.txt.
The startup server is determined by looking at the overrides, then looking inside startupserver.txt, and finally by seeing if a single server exists in the servers directory.