### PR TITLE
Fix putnpc and join for GS1.

### DIFF
--- a/server/src/NPC.cpp
+++ b/server/src/NPC.cpp
@@ -1866,7 +1866,7 @@ CString doJoins(const CString& code, FileSystem* fs)
 			CString spacecheck = c.subString(pos, loc - pos);
 			if (!spacecheck.contains(" \t") && c.bytesLeft())
 			{
-				ret << ";\xa7";
+				ret << ";\n";
 				joinList.push_back(CString() << c.readString(";") << ".txt");
 			}
 		}
@@ -1877,8 +1877,7 @@ CString doJoins(const CString& code, FileSystem* fs)
 	{
 		c = fs->load(fileName);
 		c.removeAllI("\r");
-		c.replaceAllI("\n", "\xa7");
-		ret << removeComments(c, "\xa7");
+		ret << removeComments(c);
 	}
 
 	return ret;

--- a/server/src/Player/Player.cpp
+++ b/server/src/Player/Player.cpp
@@ -3167,10 +3167,9 @@ bool Player::msgPLI_PUTNPC(CString& pPacket)
 	// Load the code.
 	CString code = m_server->getFileSystem(0)->load(ncode);
 	code.removeAllI("\r");
-	code.replaceAllI("\n", "\xa7");
 
 	// Add NPC to level
-	m_server->addNPC(nimage, code, loc[0], loc[1], m_currentLevel, true, true);
+	m_server->addNPC(nimage, code, loc[0], loc[1], m_currentLevel, false, true);
 
 	return true;
 }


### PR DESCRIPTION
The function to minify NPC script works off of normal \n line breaks.  There were cases where the script was using \xa7 linebreaks, which would cause the minify function to break and erase the whole script.

This removes the conversion of \n to \xa7 in the `Server::addNpc` code since the minify function performs that duty.

This also fixes the `join` command, which was converting to \xa7 before being passed through minify.

Finally, this updates `Player::msgPLI_PUTNPC` to properly mark the NPC type as `PUTNPC` instead of `LEVELNPC`.