### PR TITLE
Code cleanup.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -184,9 +184,11 @@ if(APPLE)
 	set(MACOSX_BUNDLE_NAME ${PROJECT_NAME})
 	set(MACOSX_BUNDLE_SHORT_VERSION_STRING "${VER_FULL}")
 elseif(WIN32)
-	set(MAKE_TESTS ON)
+	set(MAKE_TESTS OFF)
 	# Visual C++ Compiler options
 	if(MSVC)
+		set(MAKE_TESTS ON)
+
 		# Suppress secure string function warnings
 		add_definitions(-D_CRT_SECURE_NO_WARNINGS)
 

--- a/server/src/Level/Level.cpp
+++ b/server/src/Level/Level.cpp
@@ -542,7 +542,7 @@ bool Level::loadZelda(const CString& pLevelName)
 			CString level = vline[0];
 			if (vline.size() > 7)
 			{
-				for (unsigned int i = 0; i < vline.size() - 7; ++i)
+				for (size_t i = 0; i < vline.size() - 7; ++i)
 					level << " " << vline[1 + i];
 			}
 
@@ -727,7 +727,7 @@ bool Level::loadGraal(const CString& pLevelName)
 			CString level = vline[0];
 			if (vline.size() > 7)
 			{
-				for (unsigned int i = 0; i < vline.size() - 7; ++i)
+				for (size_t i = 0; i < vline.size() - 7; ++i)
 					level << " " << vline[1 + i];
 			}
 
@@ -901,7 +901,7 @@ bool Level::loadNW(const CString& pLevelName)
 			CString level(link[0]);
 			if (link.size() > 7)
 			{
-				for (auto i = 0; i < link.size() - 7; ++i)
+				for (size_t i = 0; i < link.size() - 7; ++i)
 					level << " " << link[i + 1];
 			}
 
@@ -921,7 +921,7 @@ bool Level::loadNW(const CString& pLevelName)
 			if (curLine.size() > 4)
 			{
 				offset = (int)curLine.size() - 4;
-				for (unsigned int i = 0; i < offset; ++i)
+				for (size_t i = 0; i < offset; ++i)
 					image << " " << curLine[i + 2];
 			}
 
@@ -1100,7 +1100,7 @@ void Level::saveLevel(const std::string& filename)
 	// write tiles
 	for (int layer = 0; layer < getLayers().size(); layer++)
 	{
-		auto tiles = getTiles(layer);
+		auto& tiles = getTiles(layer);
 		for (int y = 0; y < 64 /*tiles.get_height()*/; y++)
 		{
 			std::string data;

--- a/server/src/Player/Player.cpp
+++ b/server/src/Player/Player.cpp
@@ -886,8 +886,8 @@ bool Player::testSign()
 		auto level = getLevel();
 		if (level)
 		{
-			auto signs = level->getSigns();
-			for (auto sign: signs)
+			const auto& signs = level->getSigns();
+			for (const auto& sign: signs)
 			{
 				float signLoc[] = { (float)sign->getX(), (float)sign->getY() };
 				if (m_y == signLoc[1] && inrange(m_x, signLoc[0] - 1.5f, signLoc[0] + 0.5f))
@@ -2396,7 +2396,7 @@ bool Player::msgPLI_LOGIN(CString& pPacket)
 	{
 		auto& allowedVersions = m_server->getAllowedVersions();
 		bool allowed = false;
-		for (auto ver: allowedVersions)
+		for (CString ver: allowedVersions)
 		{
 			if (ver.find(":") != -1)
 			{

--- a/server/src/Player/PlayerExternalPlayers.cpp
+++ b/server/src/Player/PlayerExternalPlayers.cpp
@@ -45,7 +45,7 @@ bool Player::remPMServer(CString& option)
 	{
 		// Check if a player has disconnected
 		// By value to keep a hold of the shared_ptr until the next iteration.
-		for (auto [externalId, externalPlayer]: m_externalPlayers)
+		for (const auto& [externalId, externalPlayer]: m_externalPlayers)
 		{
 			if (option == externalPlayer->getServerName())
 			{
@@ -84,7 +84,7 @@ bool Player::updatePMPlayers(CString& servername, CString& players)
 	{
 		// Check if a player has disconnected
 		// By value to keep a hold of the shared_ptr until the next iteration.
-		for (auto [externalId, externalPlayer]: m_externalPlayers)
+		for (const auto& [externalId, externalPlayer]: m_externalPlayers)
 		{
 			bool exist2 = false;
 			for (auto& p2: players2)

--- a/server/src/Server.cpp
+++ b/server/src/Server.cpp
@@ -222,7 +222,7 @@ void Server::cleanupDeletedPlayers()
 	for (auto i = std::begin(m_deletedPlayers); i != std::end(m_deletedPlayers);)
 	{
 		// Value copy so the shared_ptr exists until the end.
-		auto player = *i;
+		PlayerPtr player = *i;
 
 #ifdef V8NPCSERVER
 		IScriptObject<Player>* playerObject = player->getScriptObject();


### PR DESCRIPTION
Visual Studio identified cases where numerical overflow could occur before widening and where unintentional copies could be made on usage of "auto".  This commit fixes those issues by widening to size_t beforehand, properly using auto&, and explicitly making value copies when necessary.