### PR TITLE
Add localhost mode: accept logins without listserver verification

### DIFF
--- a/server/include/Server.h
+++ b/server/include/Server.h
@@ -108,6 +108,7 @@ struct ExternalServerCachedSettings
 {
 	SettingCache<uint32_t> maxPlayers{"maxplayers", 128};
 	SettingCache<bool> sleepWhenNoPlayers{"sleepwhennoplayers", true};
+	SettingCache<bool> localhostMode{"localhost", false};
 	SettingCache<std::string> unstickMeLevel{"unstickmelevel", "onlinestartlocal.nw"};
 	std::array<SettingCache<float>, 2> unstickMeTile{{{"unstickmex", 30.0f}, {"unstickmey", 30.5f}}};
 	SettingCache<int> unstickMeSeconds{"unstickmetime", 30};

--- a/server/src/Server.cpp
+++ b/server/src/Server.cpp
@@ -101,7 +101,7 @@ void ExternalServerCachedSettings::bind(Server* server)
 {
 	auto& settings = server->getSettings();
 
-	settings.track(maxPlayers, sleepWhenNoPlayers);
+	settings.track(maxPlayers, sleepWhenNoPlayers, localhostMode);
 	settings.track(unstickMeLevel, unstickMeTile[0], unstickMeTile[1], unstickMeSeconds);
 	settings.track(enableBushItemDrops, enableVaseItemDrops, disableItemDropping);
 	settings.track(enableInsideSyncDistance, syncDistance[0], syncDistance[1]);

--- a/server/src/player/PlayerClient.cpp
+++ b/server/src/player/PlayerClient.cpp
@@ -434,8 +434,13 @@ bool PlayerClient::handleLogin(CString& pPacket)
 		return false;
 	}
 
+	if (m_server->cached.localhostMode.getValue())
+	{
+		log::printLine(log::server, "[Login] Localhost mode: accepting '{}' without listserver verification.", account.name);
+		return sendLogin();
+	}
+
 	// Verify login details with the serverlist.
-	// TODO: localhost mode.
 	if (!m_server->getServerList().getConnected())
 	{
 		sendPacket(CString() >> (char)PLO_DISCMESSAGE << "The login server is offline.  Try again later.");


### PR DESCRIPTION
Implements the `// TODO: localhost mode` in `PlayerClient::handleLogin`.

Adds a `localhost` server option (default `false`). When enabled, client logins skip listserver verification and call `sendLogin()` directly, with a log line noting the bypass. This makes it possible to run gs2emu fully standalone for local development and testing — currently a client login hard-fails with "The login server is offline" unless a listserver connection is up.

Tested locally on Linux (beta4, `generation = modern`): with `localhost = true` a 6.037 client logs in, loads its level, and receives weapons; with the option unset, behavior is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)