### PR TITLE
Fix crash sending a bytecode-less weapon on modern generation

### DIFF
--- a/server/src/object/Weapon.cpp
+++ b/server/src/object/Weapon.cpp
@@ -275,8 +275,12 @@ void Weapon::registerWeaponWithPlayer(std::shared_ptr<Player> player) const
 	CString weaponPacket;
 	weaponPacket >> (char)PLO_NPCWEAPONADD >> (char)name.length() << name >> (char)NPCProp::IMAGE >> (char)image.length() << image;
 
-	// Classic weapons.
-	if (m_server->Generation != ServerGeneration::MODERN && m_script.getClientByteCode().empty())
+	/*
+	 * Classic weapons: decide by whether client bytecode exists, not by server
+	 * generation. A weapon without compiled bytecode has no valid script headers
+	 * to send, so sending the never-built m_headerWithCRC would crash the server.
+	 */
+	if (m_script.getClientByteCode().empty())
 	{
 		std::string script = getClientSideScript();
 		weaponPacket >> (char)NPCProp::SCRIPT >> (short)script.length() << script;


### PR DESCRIPTION
`Weapon::registerWeaponWithPlayer` picks the "classic weapon" (plain-script) branch only when the server generation is not `MODERN`. A legacy GS1 weapon that has no compiled client bytecode — e.g. the default `-gr_movement` — on a `generation = modern` server therefore takes the bytecode branch and sends the never-built `m_headerWithCRC`, crashing the server on every client login.

This keys the branch off whether client bytecode actually exists: a weapon without bytecode has no valid script headers to send regardless of server generation, so it should always be delivered as a plain script.

Reproduced and verified on Linux beta4: stock default server with `generation = modern` segfaults the moment a 6.037 client logs in; with this patch the login completes and the weapon is delivered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)