### PR TITLE
Add IPv6 support to the player listen socket

### DIFF
--- a/server/src/Server.cpp
+++ b/server/src/Server.cpp
@@ -576,15 +576,21 @@ int Server::init(std::string_view serverip, std::string_view serverport, std::st
 
 	// Start listening on the player socket.
 	log::printLine(log::server, "Initializing player listen socket.");
-	if (m_playerSock.init((oInter.empty() ? 0 : oInter.data()), m_settings.get<std::string>("serverport").value_or(""s).c_str()))
+	const char* iface = (oInter.empty() ? 0 : oInter.data());
+	const std::string port = m_settings.get<std::string>("serverport").value_or(""s);
+	if (m_playerSock.init(iface, port.c_str(), oInter.empty() ? SOCKET_PROTOCOL_IPV6 : SOCKET_PROTOCOL_ANY) || m_playerSock.connect())
 	{
-		log::printLine(log::server, "** [Error] Could not initialize listening socket.");
-		return ERR_LISTEN;
-	}
-	if (m_playerSock.connect())
-	{
-		log::printLine(log::server, "** [Error] Could not connect listening socket.");
-		return ERR_LISTEN;
+		log::printLine(log::server, "Could not create a dual-stack listener, falling back to IPv4 only.");
+		if (m_playerSock.init(iface, port.c_str(), SOCKET_PROTOCOL_IPV4))
+		{
+			log::printLine(log::server, "** [Error] Could not initialize listening socket.");
+			return ERR_LISTEN;
+		}
+		if (m_playerSock.connect())
+		{
+			log::printLine(log::server, "** [Error] Could not connect listening socket.");
+			return ERR_LISTEN;
+		}
 	}
 
 	// Announce the ports.


### PR DESCRIPTION
## Summary

Adds IPv6 support to the player listen socket without breaking legacy IPv4 clients.

- When no `serverinterface` is configured, the server now first tries a **dual-stack IPv6 listener** (binds `::` with `IPV6_V6ONLY` disabled), so IPv6 clients can connect while legacy IPv4 clients keep connecting exactly as before via v4-mapped addresses.
- When an explicit `serverinterface` is configured, the address family follows whatever `getaddrinfo` resolves for it (`SOCKET_PROTOCOL_ANY`), so both v4 and v6 interface addresses work.
- If the host, the interface, or the socket library cannot do IPv6, the server logs one line and **falls back to the previous IPv4-only behavior**. In particular, against the currently pinned gs2lib this fallback always engages, so this PR is safe to merge on its own with zero behavior change.

## Companion gs2lib change

The dual-stack path needs a small gs2lib fix — `CSocket::connect()` currently hardcodes `socket(AF_INET, ...)` even though `init()` already resolves via `getaddrinfo` into a `sockaddr_storage`. Patch attached below (applies to the pinned `e0d4217`); after applying it to gs2lib and bumping the `GIT_TAG` in `server/CMakeLists.txt`, dual-stack turns on. Alongside the family fix it disables `IPV6_V6ONLY` for AF_INET6 server sockets and normalizes IPv4-mapped addresses (`::ffff:a.b.c.d` → `a.b.c.d`) in `getRemoteIp()`, so every existing IPv4 string consumer (IP bans, admin IP ranges, the `IPADDR` player prop via `inet_pton`) sees identical values for IPv4 clients arriving through the dual-stack listener.

```diff
diff --git a/src/CSocket.cpp b/src/CSocket.cpp
index 86f26e3..32d5e26 100644
--- a/src/CSocket.cpp
+++ b/src/CSocket.cpp
@@ -406,10 +406,11 @@ int CSocket::connect()
 	properties.state = SOCKET_STATE_CONNECTING;
 
 	// Create socket.
+	int family = properties.addresslen != 0 ? reinterpret_cast<struct sockaddr*>(&properties.address)->sa_family : AF_INET;
 	if (properties.protocol == SOCKET_PROTOCOL_TCP)
-		properties.handle = socket(AF_INET, SOCK_STREAM, 0);
+		properties.handle = socket(family, SOCK_STREAM, 0);
 	else
-		properties.handle = socket(AF_INET, SOCK_DGRAM, 0);
+		properties.handle = socket(family, SOCK_DGRAM, 0);
 
 	// Make sure the socket was created correctly.
 	if (properties.handle == INVALID_SOCKET)
@@ -419,6 +420,15 @@ int CSocket::connect()
 		return SOCKET_INVALID;
 	}
 
+#ifdef IPV6_V6ONLY
+	// Use dual-stack so IPv4 clients can connect to the IPv6 listener.
+	if (properties.type == SOCKET_TYPE_SERVER && family == AF_INET6)
+	{
+		int v6only = 0;
+		setsockopt(properties.handle, IPPROTO_IPV6, IPV6_V6ONLY, (char*)&v6only, sizeof(v6only));
+	}
+#endif
+
 	// Bind the socket if it is a server-type socket.
 	if (properties.type == SOCKET_TYPE_SERVER)
 	{
@@ -828,6 +838,10 @@ const char* CSocket::getRemoteIp() const
 	if (getnameinfo(reinterpret_cast<const struct sockaddr *>(&properties.address), sizeof(struct sockaddr_storage), host, 1025, nullptr, 0, NI_NUMERICHOST))
 		return nullptr;
 
+	// Preserve plain IPv4 strings for clients accepted by a dual-stack listener.
+	if (strncmp(host, "::ffff:", 7) == 0 && strchr(host + 7, ':') == 0 && strchr(host + 7, '.') != 0)
+		memmove(host, host + 7, strlen(host + 7) + 1);
+
 	return &host[0];
 }
```

## Testing (Linux, v6.037 client)

| Build | Result |
|---|---|
| This PR + pinned gs2lib | Logs the fallback line, listens on `0.0.0.0` — IPv4 clients connect, behavior identical to beta4 today |
| This PR + patched gs2lib | Listens dual-stack on `::` — full automated client QA suite (connection, movement, combat, chat, chests, multi-player visibility/PvP/chat) passes **16/16 over IPv4 and 16/16 over IPv6**; a mixed session (one client on `127.0.0.1`, one on `::1`) sees each other and interacts normally |

Also verified server-side IP strings with the patched gs2lib: an IPv4 client's persisted account IP stays `127.0.0.1` (not `::ffff:127.0.0.1`); an IPv6 client records `::1`.

Notes:
- Accounts restricted with IPv4-style `IPRANGE` masks (e.g. `*.*.*.*`) won't match IPv6 client addresses — such logins are rejected until the range is widened (e.g. `*`). That seemed like the right conservative default for admin IP allowlists.
- For native IPv6 clients the numeric `IPADDR` player prop stays 0 (it's a 32-bit value); `account.ipAddress` carries the full v6 string.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
